### PR TITLE
FIX : Menus non affichés correctement

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,5 @@
+# CHANGELOG FOR pricelist MODULE
+
+## Not Released
+
+- FIX : Remove creation of new user in massactionPricelist.php

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,4 +2,4 @@
 
 ## Not Released
 
-- FIX : Remove creation of new user in massactionPricelist.php - 31/03/2021 - 1.0.2
+- FIX : Remove creation of new user in massactionPricelist.php - *31/03/2021* - 1.0.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,4 +2,4 @@
 
 ## Not Released
 
-- FIX : Remove creation of new user in massactionPricelist.php
+- FIX : Remove creation of new user in massactionPricelist.php - 31/03/2021 - 1.0.2

--- a/core/modules/modpricelist.class.php
+++ b/core/modules/modpricelist.class.php
@@ -59,7 +59,7 @@ class modpricelist extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module pricelist";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.1';
+		$this->version = '1.0.2';
 		// Key used in llx_const table to save module status enabled/disabled (where PRICELIST is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/massactionPricelist.php
+++ b/massactionPricelist.php
@@ -18,7 +18,6 @@ $pricelistMassaction = new PricelistMassaction($db);
 $pricelistMassactionsIgnored = new PricelistMassactionIgnored($db);
 $form = new Form($db);
 $formA = new TFormCore($db);
-$user = new User($db);
 
 
 $id = GETPOST('id','int');
@@ -105,7 +104,7 @@ $general_propreties = array(
 	'view_type' => 'list'
 	, 'limit' => array(
 		'nbLine' => $nbLine
-		,'page' => $pager
+		,'page' => $page
 	)
 	, 'subQuery' => array()
 	, 'link' => array()

--- a/massactionPricelist.php
+++ b/massactionPricelist.php
@@ -104,7 +104,7 @@ $general_propreties = array(
 	'view_type' => 'list'
 	, 'limit' => array(
 		'nbLine' => $nbLine
-		,'page' => $page
+		,'page' => $pager
 	)
 	, 'subQuery' => array()
 	, 'link' => array()


### PR DESCRIPTION
### FIX : Sur la page massactionPricelist.php, les menus n'étaient pas affichés correctement

**En effet, depuis la liste des actions de masse, lorsque l'utilisateur cliquant sur un lien vers un objet de la liste, il était envoyé vers la page massactionPricelist.php depuis laquelle la plupart des menus étaient inaccessibles :**
- Suppression de la création d'utilisateur sur génération de la page : massactionPricelist.php (cela provoquait des problèmes de droit/d’accès aux différents menu 